### PR TITLE
Update Jest project configurations to include new app module tests

### DIFF
--- a/jest.projects.js
+++ b/jest.projects.js
@@ -182,7 +182,10 @@ const defaultProject = {
       '/tests/lib/validation/schema-241-alignment.test.js',
       '\\\\tests\\\\lib\\\\validation\\\\schema-241-alignment.test.js',
       'lib/validation/schema-241-alignment.test.js',
-      'schema-241-alignment\\.test\\.js'
+      'schema-241-alignment\\.test\\.js',
+      '/tests/lib/app/app.test.js',
+      '\\\\tests\\\\lib\\\\app\\\\app.test.js',
+      'lib/app/app.test.js'
     ];
     if (process.env.INCLUDE_LOCAL_TESTS !== 'true') {
       patterns.push('/tests/local/');
@@ -269,7 +272,8 @@ const isolatedProjects = [
   ]),
   makeIsolatedProject('generator-error-paths', ['**/tests/lib/generator/generator-error-paths.test.js']),
   makeIsolatedProject('secrets-databaselog', ['**/tests/lib/core/secrets-databaselog.test.js']),
-  makeIsolatedProject('schema-241-alignment', ['**/tests/lib/validation/schema-241-alignment.test.js'])
+  makeIsolatedProject('schema-241-alignment', ['**/tests/lib/validation/schema-241-alignment.test.js']),
+  makeIsolatedProject('app-module', ['**/tests/lib/app/app.test.js'])
 ];
 
 const allProjects = [defaultProject, ...isolatedProjects];

--- a/tests/lib/app/app.test.js
+++ b/tests/lib/app/app.test.js
@@ -1,6 +1,9 @@
 /**
  * Tests for AI Fabrix Builder Application Module
  *
+ * Isolated Jest project `app-module` — uses real `fs` + `util.promisify` partial mock; avoid sharing
+ * a worker with suites that `jest.mock('fs')` or fully mock `util`.
+ *
  * @fileoverview Unit tests for app.js module
  * @author AI Fabrix Team
  * @version 2.0.0


### PR DESCRIPTION
- Added `app-module` as an isolated Jest project, incorporating tests from `lib/app/app.test.js` to enhance test coverage.
- Updated the default project patterns to include paths for the new app module tests, ensuring proper test isolation and execution.